### PR TITLE
Add Dragon GUI

### DIFF
--- a/src/main/java/info/ata4/minecraft/dragon/client/gui/DragonGui.java
+++ b/src/main/java/info/ata4/minecraft/dragon/client/gui/DragonGui.java
@@ -1,0 +1,75 @@
+package info.ata4.minecraft.dragon.client.gui;
+
+import org.lwjgl.opengl.GL11;
+
+import info.ata4.minecraft.dragon.server.entity.EntityTameableDragon;
+import info.ata4.minecraft.dragon.server.inventory.ContainerDragonGui;
+import net.minecraft.client.gui.inventory.GuiContainer;
+import net.minecraft.client.gui.inventory.GuiInventory;
+import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.Container;
+import net.minecraft.util.ResourceLocation;
+
+/**
+ * <p>Represents the graphical interface that is opened when a player shift-right-clicks on their tamed dragon.</p>
+ * 
+ * <p>This class handles drawing the interface. For inventory management, see {@link ContainerDragonGui}.</p>
+ * 
+ * @see ContainerDragonGui
+ * @author TerrorBite
+ *
+ */
+public class DragonGui extends GuiContainer {
+
+	private EntityTameableDragon dragon;
+	private EntityPlayer player;
+	
+	public DragonGui(EntityPlayer player, EntityTameableDragon dragon) {
+		super(new ContainerDragonGui(player, dragon));
+		this.dragon = dragon;
+		this.player = player;
+		
+		this.xSize = 176;
+		this.ySize = 166;
+	}
+
+	@Override
+	protected void drawGuiContainerBackgroundLayer(float time, int mouseX, int mouseY) {
+		// Use built-in horse GUI as the base image
+		this.mc.getTextureManager().bindTexture(new ResourceLocation("minecraft", "textures/gui/container/horse.png"));
+		this.drawTexturedModalRect(guiLeft, guiTop, 0, 0, xSize, ySize);
+		
+		this.renderDragon(mouseX, mouseY);
+	}
+	
+	@Override
+	protected void drawGuiContainerForegroundLayer(int mouseX, int mouseY) {
+        this.fontRendererObj.drawString(this.dragon.getDisplayName().getUnformattedText(), 8, 6, 4210752);
+        this.fontRendererObj.drawString(this.player.inventory.getDisplayName().getUnformattedText(), 8, this.ySize - 93, 4210752);
+	}
+	
+	private void renderDragon(int mouseX, int mouseY) {
+		// Dragons are big, so we will disable drawing outside of the window
+		GL11.glEnable(GL11.GL_SCISSOR_TEST);
+		
+		// Note: glScissor() takes screen coordinates, so we need to know Minecraft's GUI scaling factor.
+		int scale = mc.displayHeight / this.height;
+		// OpenGL screen coordinates have an origin in the bottom left.
+		GL11.glScissor(scale*(this.guiLeft+26), mc.displayHeight-scale*(this.guiTop+70), scale*52, scale*52);
+		
+		// Just in case, ensure color is set correctly for drawing textures
+		GlStateManager.color(1.0f, 1.0f, 1.0f, 1.0f);
+
+		// The black window starts at 26,18 in GUI coordinates, and is 52x52 in size
+		// Calculate the center of that window in GUI coordinates.
+		int dragonX = this.guiLeft + 52, dragonY = this.guiTop + 44;
+		// Render the dragon in the target area. Shift render location down because mob positions are based at their feet.
+		// Parameters: X_pos, Y_pos, size, X_look, Y_look, entity
+		GuiInventory.drawEntityOnScreen(dragonX, dragonY+22, 14, dragonX-mouseX, dragonY-mouseY, this.dragon);
+		
+		// Disable scissoring
+		GL11.glDisable(GL11.GL_SCISSOR_TEST);
+	}
+	
+}

--- a/src/main/java/info/ata4/minecraft/dragon/server/CommonProxy.java
+++ b/src/main/java/info/ata4/minecraft/dragon/server/CommonProxy.java
@@ -14,6 +14,7 @@ import info.ata4.minecraft.dragon.server.block.BlockDragonBreedEgg;
 import info.ata4.minecraft.dragon.server.cmd.CommandDragon;
 import info.ata4.minecraft.dragon.server.entity.EntityTameableDragon;
 import info.ata4.minecraft.dragon.server.handler.DragonEggBlockHandler;
+import info.ata4.minecraft.dragon.server.handler.GuiHandler;
 import info.ata4.minecraft.dragon.server.item.ItemDragonBreedEgg;
 import net.minecraft.command.ServerCommandManager;
 import net.minecraft.server.MinecraftServer;
@@ -23,6 +24,7 @@ import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLServerStartingEvent;
 import net.minecraftforge.fml.common.event.FMLServerStoppedEvent;
+import net.minecraftforge.fml.common.network.NetworkRegistry;
 import net.minecraftforge.fml.common.registry.EntityRegistry;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 
@@ -46,6 +48,9 @@ public class CommonProxy {
         registerEntities();
 
         MinecraftForge.EVENT_BUS.register(new DragonEggBlockHandler());
+        
+        // Register GUI handler with Forge
+        NetworkRegistry.INSTANCE.registerGuiHandler(DragonMounts.instance, new GuiHandler());
     }
 
     public void onPostInit(FMLPostInitializationEvent event) {

--- a/src/main/java/info/ata4/minecraft/dragon/server/entity/helper/DragonInteractHelper.java
+++ b/src/main/java/info/ata4/minecraft/dragon/server/entity/helper/DragonInteractHelper.java
@@ -27,6 +27,7 @@ public class DragonInteractHelper extends DragonHelper {
     public DragonInteractHelper(EntityTameableDragon dragon) {
         super(dragon);
         
+        actions.add(new DragonInteractGui(dragon));
         actions.add(new DragonInteractEat(dragon));
         actions.add(new DragonInteractTame(dragon));
         actions.add(new DragonInteractSaddle(dragon));

--- a/src/main/java/info/ata4/minecraft/dragon/server/entity/interact/DragonInteractGui.java
+++ b/src/main/java/info/ata4/minecraft/dragon/server/entity/interact/DragonInteractGui.java
@@ -1,0 +1,56 @@
+package info.ata4.minecraft.dragon.server.entity.interact;
+
+import info.ata4.minecraft.dragon.DragonMounts;
+import info.ata4.minecraft.dragon.server.entity.EntityTameableDragon;
+import info.ata4.minecraft.dragon.server.handler.GuiHandler;
+import net.minecraft.entity.passive.EntityHorse;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.text.TextComponentString;
+
+/**
+ * Opens the Dragon GUI when interacting with a dragon while crouching.
+ * 
+ * @author TerrorBite <terrorbite at lethargiclion.net>
+ *
+ */
+public class DragonInteractGui extends DragonInteract {
+
+	public DragonInteractGui(EntityTameableDragon dragon) {
+		super(dragon);
+	}
+
+	@Override
+	public boolean interact(EntityPlayer player, ItemStack item) {
+
+		if (player.isSneaking()) {
+			if (dragon.isServer()) {
+				// Don't run this code on client side.
+				
+				if (dragon.isTamedFor(player)) {
+					// Dragon is tamed and owned by us. Open the dragon GUI
+					player.openGui(DragonMounts.instance, GuiHandler.DRAGON_GUI, player.getEntityWorld(), dragon.getEntityId(), 0, 0);
+					
+				} else if (dragon.isTamed()) {
+					// This dragon is tamed, but we don't own it
+					// Try and get owner's name, use generic string if owner not online
+					String ownerName = dragon.getOwner() == null ? "another player" : dragon.getOwner().getName();
+					player.addChatMessage(new TextComponentString(
+							String.format("You can't control %s's dragon.", ownerName)));
+					
+				} else {
+					// This dragon is NOT tamed
+					player.addChatMessage(new TextComponentString("You can't control an untamed dragon."));
+				}
+			}
+			// Player is sneaking. Indicate a match, i.e. interaction was handled.
+			// Other interaction handlers won't be checked.
+			// Returns true regardless if this code runs on server or client - we want to stop the event
+			return true;
+		}
+		// Player is not sneaking, pass on to other interaction handlers
+		return false;
+	}
+
+}

--- a/src/main/java/info/ata4/minecraft/dragon/server/handler/GuiHandler.java
+++ b/src/main/java/info/ata4/minecraft/dragon/server/handler/GuiHandler.java
@@ -1,0 +1,66 @@
+package info.ata4.minecraft.dragon.server.handler;
+
+import info.ata4.minecraft.dragon.DragonMounts;
+import info.ata4.minecraft.dragon.client.gui.DragonGui;
+import info.ata4.minecraft.dragon.server.entity.EntityTameableDragon;
+import info.ata4.minecraft.dragon.server.inventory.ContainerDragonGui;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.world.World;
+import net.minecraftforge.fml.common.network.IGuiHandler;
+
+/**
+ * <p>The GuiHandler for DragonMounts, it handles all player.openGui() requests.</p>
+ * <p>Currently the only GUI that is available is {@link #DRAGON_GUI}.
+ * @author TerrorBite
+ *
+ */
+public class GuiHandler implements IGuiHandler {
+
+	/**
+	 * This value indicates that a {@link DragonGui} should be opened.
+	 */
+	public static final int DRAGON_GUI = 0;
+	
+	/**
+	 * <p>Called by Forge on the client side. Should return an instance of GuiContainer.</p>
+	 * 
+	 * <p>Mod code SHOULD NOT directly call this method; instead it should call {@link EntityPlayer#openGui(Object, int, World, int, int, int)}.</p>
+	 * @param guiID The integer ID of the GUI that we are being asked to open. Currently, {@link #DRAGON_GUI} is the only option.
+	 * @param player The player who will be shown this GUI.
+	 * @param world The world in which the block or entity associated with this GUI resides.
+	 * @param x Either the x-coordinate of the block associated with this GUI, or the Entity ID of the entity associated with this GUI.
+	 * @param y The y-coordinate of the block associated with this GUI. Ignored if the GUI is associated with an entity instead.
+	 * @param z The z-coordinate of the block associated with this GUI. Ignored if the GUI is associated with an entity instead.
+	 */
+	@Override
+	public Object getClientGuiElement(int guiID, EntityPlayer player, World world, int x, int y, int z) {
+		switch (guiID) {
+		case DRAGON_GUI:
+			return new DragonGui(player, (EntityTameableDragon)world.getEntityByID(x));
+		default:
+			return null;
+		}
+	}
+
+	/**
+	 * <p>Called by Forge on the server side. Should return an instance of Container.</p>
+	 * 
+	 * <p>Mod code SHOULD NOT directly call this method; instead it should call {@link EntityPlayer#openGui(Object, int, World, int, int, int)}.</p>
+	 * @param guiID The integer ID of the GUI that we are being asked to open. Currently, {@link #DRAGON_GUI} is the only option.
+	 * @param player The player who will be shown this GUI.
+	 * @param world The world in which the block or entity associated with this GUI resides.
+	 * @param x Either the x-coordinate of the block associated with this GUI, or the Entity ID of the entity associated with this GUI.
+	 * @param y The y-coordinate of the block associated with this GUI. Ignored if the GUI is associated with an entity instead.
+	 * @param z The z-coordinate of the block associated with this GUI. Ignored if the GUI is associated with an entity instead.
+	 */
+	@Override
+	public Object getServerGuiElement(int guiID, EntityPlayer player, World world, int x, int y, int z) {
+		switch (guiID) {
+		case DRAGON_GUI:
+			return new ContainerDragonGui(player, (EntityTameableDragon)world.getEntityByID(x));
+		default:
+			return null;
+		}
+	}
+
+}

--- a/src/main/java/info/ata4/minecraft/dragon/server/inventory/ContainerDragonGui.java
+++ b/src/main/java/info/ata4/minecraft/dragon/server/inventory/ContainerDragonGui.java
@@ -1,0 +1,124 @@
+package info.ata4.minecraft.dragon.server.inventory;
+
+import org.apache.logging.log4j.Level;
+
+import info.ata4.minecraft.dragon.server.entity.EntityTameableDragon;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.Container;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.inventory.InventoryBasic;
+import net.minecraft.inventory.Slot;
+import net.minecraft.item.ItemSaddle;
+import net.minecraft.item.ItemStack;
+import net.minecraft.launchwrapper.LogWrapper;
+import info.ata4.minecraft.dragon.client.gui.DragonGui; // used in javadoc
+
+/**
+ * <p>Handles inventory in the GUI that is opened when a player shift-right-clicks on their tamed dragon.
+ * Extends {@link Container}, which handles synchronizing changes to the GUI's inventory slots between the
+ * client and the server.</p>
+ * 
+ * <p>Dragons do not actually have an inventory of their own, so this class creates an internal instance of
+ * {@link DragonInventory} which is used while the GUI is open. Changes to that inventory trigger updates to
+ * the dragon's internal state. When the GUI is closed, the inventory instance is discarded.</p>
+ * 
+ * <p>This class is responsible for specifying what inventory slots appear in the GUI and where they are located,
+ * but does not actually draw the GUI. For that, see {@link DragonGui}.</p>
+ * 
+ * @author TerrorBite
+ * @see DragonGui
+ * @see DragonInventory
+ *
+ */
+public class ContainerDragonGui extends Container {
+	
+	private EntityTameableDragon dragon;
+	private IInventory inv;
+
+	/**
+	 * Constructor for this class.
+	 * @param player The player who is interacting with their dragon.
+	 * @param dragon The dragon being interacted with.
+	 */
+	public ContainerDragonGui(EntityPlayer player, EntityTameableDragon dragon) {
+		this.dragon = dragon;
+		this.inv = new DragonInventory(dragon);
+		
+		// Saddle slot (dragon slot 0)
+		// Container slot ID 0
+		this.addSlotToContainer(new SaddleSlot(inv, 0, 8, 18));
+		
+	    // Player's non-hotbar inventory (player slots 9-35)
+		// Container slot IDs 1-27
+	    for (int y = 0; y < 3; ++y) {
+	        for (int x = 0; x < 9; ++x) {
+	            this.addSlotToContainer(new Slot(player.inventory, x + y * 9 + 9, 8 + x * 18, 84 + y * 18));
+	        }
+	    }
+
+	    // Player's hotbar (player slots 0-8)
+	    // Container slot IDs 28-36
+	    for (int x = 0; x < 9; ++x) {
+	        this.addSlotToContainer(new Slot(player.inventory, x, 8 + x * 18, 142));
+	    }
+	}
+
+	@Override
+	/**
+	 * Gets whether the player is able to interact with the dragon that owns this container.
+	 * I don't know if this method ever actually gets called, because we are handling
+	 * player interactions ourselves in <code>DragonInteractGui</code>.
+	 */
+	public boolean canInteractWith(EntityPlayer player) {
+		// Dragon is tamed by this player and player is within 8 blocks of the dragon
+		return this.dragon.isTamedFor(player) && (this.dragon.getDistanceToEntity(player) < 8.0f);
+	}
+	
+	/**
+	 * This method handles shift-clicking items to and from the slots in the inventory.
+	 */
+	@Override
+	public ItemStack transferStackInSlot(EntityPlayer player, int fromSlot) {
+		// Begin boilerplate code
+	    ItemStack previous = null;
+	    Slot sourceSlot = (Slot) this.inventorySlots.get(fromSlot);
+
+	    if (sourceSlot != null && sourceSlot.getHasStack()) {
+	        ItemStack current = sourceSlot.getStack();
+	        previous = current.copy();
+	        // End boilerplate
+	        
+	        
+	        if(fromSlot < 1) { // Shift-click: Dragon => Player
+	        	// Note, mergeItemStack() will modify the ItemStack passed in as it moves items around
+	        	if(!this.mergeItemStack(current, 1, 36, true)) return null;
+	        }
+	        else { // Shift-click: Player => Dragon
+	        	if(current.getItem() instanceof ItemSaddle) {
+	        		if(this.getSlot(0).getHasStack()) {
+	        			// saddle slot is full
+	        			return null;
+	        		}
+		        	this.getSlot(0).putStack(previous);
+		        	current.stackSize = 0;
+	        	}	        		
+	        	//TODO: Handle dragon armor being shift-clicked in
+	        	else return null; // item won't fit, do nothing
+
+	        }
+	        
+	        
+	        // More boilerplate code
+	        if (current.stackSize == 0)
+	            sourceSlot.putStack((ItemStack) null);
+	        else
+	            sourceSlot.onSlotChanged();
+
+	        if (current.stackSize == previous.stackSize)
+	            return null;
+	        sourceSlot.onPickupFromSlot(player, current);
+	    }
+	    return previous;
+	    // end boilerplate
+	}
+}

--- a/src/main/java/info/ata4/minecraft/dragon/server/inventory/DragonInventory.java
+++ b/src/main/java/info/ata4/minecraft/dragon/server/inventory/DragonInventory.java
@@ -1,0 +1,81 @@
+package info.ata4.minecraft.dragon.server.inventory;
+
+import javax.annotation.Nullable;
+
+import org.apache.logging.log4j.Level;
+
+import info.ata4.minecraft.dragon.DragonMounts;
+import info.ata4.minecraft.dragon.server.entity.EntityTameableDragon;
+import net.minecraft.client.Minecraft;
+import net.minecraft.entity.EntityLiving;
+import net.minecraft.inventory.InventoryBasic;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemSaddle;
+import net.minecraft.item.ItemStack;
+import net.minecraft.launchwrapper.LogWrapper;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.common.registry.GameData;
+import net.minecraftforge.fml.common.registry.GameRegistry;
+
+/**
+ * <p>A "fake" inventory used by {@link ContainerDragonGui} to allow items such as saddles
+ * to be equipped to a tamed dragon. The inventory is "fake" because it is not persistent and exists only
+ * as long as the GUI that requires it is open. However, changes to the inventory's contents <i>do</i> have
+ * persistent effects, as follows:</p>
+ * 
+ * <ul><li><b>Slot 0:</b> The dragon's "saddled" state will be updated when a saddle is added to or removed from this slot.</li>
+ * <li><b>Slot 1:</b> Currently unused, placing items into this slot has no effect.
+ * Intended to be used for dragon armor in future.</li></ul>
+ * @author TerrorBite
+ *
+ */
+public class DragonInventory extends InventoryBasic {
+	
+	private EntityTameableDragon dragon;
+	private final static Item SADDLE = Item.REGISTRY.getObject(new ResourceLocation("minecraft:saddle"));
+
+	/**
+	 * Constructs a new <code>DragonInventory</code> instance for the given dragon.
+	 * @param dragon The dragon whose state will be used to initialize this inventory, and whose state
+	 * will be affected by changes to this inventory.
+	 */
+	public DragonInventory(EntityTameableDragon dragon) {
+		super(dragon.getName(), dragon.hasCustomName(), 2);
+		this.dragon = dragon;
+		if(dragon.isServer()) {
+			super.setInventorySlotContents(0, dragon.isSaddled() ? new ItemStack(SADDLE) : null);
+		}
+	}
+	
+	/**
+	 * In addition to the functionality of {@link InventoryBasic#setInventorySlotContents(int, ItemStack)},
+	 * this method updates the dragon's state upon certain changes to inventory slots. See the description of
+	 * {@link DragonInventory} for a full list.
+	 * @param slot The slot number to update.
+	 * @param stack The {@link ItemStack} to place into the slot.
+	 */
+	@Override
+	public void setInventorySlotContents(int slot, @Nullable ItemStack stack) {
+		super.setInventorySlotContents(slot, stack);
+		if(dragon.isServer()) {
+			switch(slot) {
+			case 0:
+				// Saddle slot
+				if(stack != null) {
+					if(stack.getItem() instanceof ItemSaddle) {
+						LogWrapper.log("DragonMounts", Level.INFO, "Saddle was placed onto %s", dragon.getName());
+						this.dragon.setSaddled(true);
+					}
+					else {
+						LogWrapper.log("DragonMounts", Level.INFO, "Unknown item placed into %s", dragon.getName());
+					}
+				} else {
+					LogWrapper.log("DragonMounts", Level.INFO, "Saddle was removed from %s", dragon.getName());
+					this.dragon.setSaddled(false);
+				}
+			default:
+				return;
+			}
+		}
+	}
+}

--- a/src/main/java/info/ata4/minecraft/dragon/server/inventory/SaddleSlot.java
+++ b/src/main/java/info/ata4/minecraft/dragon/server/inventory/SaddleSlot.java
@@ -1,0 +1,29 @@
+package info.ata4.minecraft.dragon.server.inventory;
+
+import net.minecraft.inventory.IInventory;
+import net.minecraft.inventory.InventoryBasic;
+import net.minecraft.inventory.Slot;
+import net.minecraft.item.ItemStack;
+import info.ata4.minecraft.dragon.server.inventory.ContainerDragonGui; // used by javadoc
+
+/**
+ * A slot designed to accept a single saddle and nothing else. Used by {@link ContainerDragonGui}.
+ * @author TerrorBite
+ *
+ */
+public class SaddleSlot extends Slot {
+
+	public SaddleSlot(IInventory inv, int index, int xPos, int yPos) {
+		super(inv, index, xPos, yPos);
+	}
+	
+	@Override
+	public int getSlotStackLimit() {
+		return 1;
+	}
+	
+	public boolean isItemValid(ItemStack stack) {
+		return stack == null || stack.getItem() instanceof net.minecraft.item.ItemSaddle;
+	}
+
+}


### PR DESCRIPTION
Adds GUI that can be opened by right-clicking on a tamed dragon while
sneaking. Currently, the only functionality this GUI offers is adding
and removing the dragon's saddle. Further functionality will be added.